### PR TITLE
Changed base class in Ajax block.

### DIFF
--- a/app/code/community/Lesti/Version/Block/Adminhtml/Data/Form/Element/Version/Ajax.php
+++ b/app/code/community/Lesti/Version/Block/Adminhtml/Data/Form/Element/Version/Ajax.php
@@ -16,7 +16,7 @@
 /**
  * Class Lesti_Version_Block_Adminhtml_Data_Form_Element_Version_Ajax
  */
-class Lesti_Version_Block_Adminhtml_Data_Form_Element_Version_Ajax extends Mage_Adminhtml_Block_Template
+class Lesti_Version_Block_Adminhtml_Data_Form_Element_Version_Ajax extends Varien_Data_Form_Element_Abstract
 {
 
     public function __construct($attributes=array())


### PR DESCRIPTION
Got following error on 1.9.0.1:
Recoverable Error: Argument 1 passed to Varien_Data_Form_Element_Abstract::addElement() must be an instance of Varien_Data_Form_Element_Abstract, instance of Lesti_Version_Block_Adminhtml_Data_Form_Element_Version_Ajax given, called in /var/www/lib/Varien/Data/Form/Abstract.php on line 148 and defined  in /var/www/lib/Varien/Data/Form/Element/Abstract.php on line 55

Changing base class to Varien_Data_Form_Element_Abstract did the trick for me.
